### PR TITLE
Fixed aggregation of false negatives in benchmark

### DIFF
--- a/src/be/tarsos/lsh/LSH.java
+++ b/src/be/tarsos/lsh/LSH.java
@@ -108,7 +108,7 @@ public class LSH {
 			//The number of true positives is Union of results - intersection. 
 			truePositives += lshResult.size() + linearResult.size() - set.size();
 			//The number of false Negatives the number of vectors that exceed the number of lsh results . 
-			falseNegatives =  set.size() - lshResult.size();
+			falseNegatives +=  set.size() - lshResult.size();
 							
 			//result is only correct if all nearest neighbours are the same (rather strict).
 			boolean correct = true;


### PR DESCRIPTION
The original benchmark code does the following for each query to the dataset:

    falsePositives += set.size() - linearResult.size();
    truePositives += lshResult.size() + linearResult.size() - set.size();
    falseNegatives =  set.size() - lshResult.size();

The three numbers are then compared against each other to calculate precision and recall statistics.
However, `falseNegatives` is being calculated incorrectly due to the use of `=` instead of `+=` like the rest.
This causes the false negatives for the last query to be used instead of the aggregated number of false negatives for all queries.
The solution is to simply replace `=` with `+=`.