### PR TITLE
DO NOT deserialize when building index

### DIFF
--- a/src/be/tarsos/lsh/LSH.java
+++ b/src/be/tarsos/lsh/LSH.java
@@ -65,7 +65,8 @@ public class LSH {
 		// Do we want to deserialize or build a new index???
 		// index = new Index(hashFamily, numberOfHashes, numberOfHashTables);
 		// Deserialization can cause duplicates?
-		index = Index.deserialize(hashFamily, numberOfHashes, numberOfHashTables);
+		//index = Index.deserialize(hashFamily, numberOfHashes, numberOfHashTables);
+		index = new Index(hashFamily, numberOfHashes, numberOfHashTables);
 		if(dataset != null){
 			for(Vector vector : dataset){
 				index.index(vector);


### PR DESCRIPTION
When initializing the LSH index, the buildIndex function is called. Currently it deserializes a stored index (if it exists) and then adds any new items in the dataset to the index. However, **the user does not get any indication that this is being done**.

Suppose the user creates an index for dataset 1. Then, the user uses the same hash family, no. of hashes, and no. of hash tables for dataset 2. Then the data from dataset 1 will be included into the index for dataset 2, **whether the user wants that or not**.

This problem is evident when running the benchmark multiple times in a row. The first time it will give correct results, but all later runs will give incorrect results as they will be running on a dataset of a different size than advertised.

Therefore I propose removing the deserialization call for now and replacing it with a constructor for a new index. Ideally some sort of option should be given to the user in the front end asking if the serialized data should be included in the new index.