### PR TITLE
Fixed wrong hash formula in CityBlockHash

### DIFF
--- a/src/be/tarsos/lsh/HashTable.java
+++ b/src/be/tarsos/lsh/HashTable.java
@@ -43,7 +43,7 @@ class HashTable implements Serializable {
 	 * Contains the mapping between a combination of a number of hashes (encoded
 	 * using an integer) and a list of possible nearest neighbours
 	 */
-	private HashMap<Integer,List<Vector>> hashTable;
+	private HashMap<String,List<Vector>> hashTable;
 	private HashFunction[] hashFunctions;
 	private HashFamily family;
 	
@@ -58,7 +58,7 @@ class HashTable implements Serializable {
 	 *            functions, and is used therefore.
 	 */
 	public HashTable(int numberOfHashes,HashFamily family){
-		hashTable = new HashMap<Integer, List<Vector>>();
+		hashTable = new HashMap<String, List<Vector>>();
 		this.hashFunctions = new HashFunction[numberOfHashes];
 		for(int i=0;i<numberOfHashes;i++){
 			hashFunctions[i] = family.createHashFunction();
@@ -78,7 +78,7 @@ class HashTable implements Serializable {
 	 *         list of candidates is returned.
 	 */
 	public List<Vector> query(Vector query) {
-		Integer combinedHash = hash(query);
+		String combinedHash = hash(query);
 		if(hashTable.containsKey(combinedHash))
 			return hashTable.get(combinedHash);
 		else
@@ -90,7 +90,7 @@ class HashTable implements Serializable {
 	 * @param vector
 	 */
 	public void add(Vector vector) {
-		Integer combinedHash = hash(vector);
+		String combinedHash = hash(vector);
 		if(! hashTable.containsKey(combinedHash)){
 			hashTable.put(combinedHash, new ArrayList<Vector>());
 		}
@@ -102,12 +102,12 @@ class HashTable implements Serializable {
 	 * @param vector The vector to calculate the combined hash for.
 	 * @return An integer representing a combined hash.
 	 */
-	private Integer hash(Vector vector){
+	private String hash(Vector vector){
 		int hashes[] = new int[hashFunctions.length];
 		for(int i = 0 ; i < hashFunctions.length ; i++){
 			hashes[i] = hashFunctions[i].hash(vector);
 		}
-		Integer combinedHash = family.combine(hashes);
+		String combinedHash = family.combine(hashes);
 		return combinedHash;
 	}
 

--- a/src/be/tarsos/lsh/families/CityBlockHash.java
+++ b/src/be/tarsos/lsh/families/CityBlockHash.java
@@ -49,7 +49,7 @@ public class CityBlockHash implements HashFunction {
 	public int hash(Vector vector){
 		int hash[] = new int[randomPartition.getDimensions()];
 		for(int d=0; d<randomPartition.getDimensions(); d++) {
-			hash[d] =  (int) ((vector.get(d)-randomPartition.get(d)) / Double.valueOf(w));
+			hash[d] =  (int) Math.floor((vector.get(d)-randomPartition.get(d)) / Double.valueOf(w));
 		}
 		return Arrays.hashCode(hash);
 	}

--- a/src/be/tarsos/lsh/families/CityBlockHash.java
+++ b/src/be/tarsos/lsh/families/CityBlockHash.java
@@ -49,7 +49,7 @@ public class CityBlockHash implements HashFunction {
 	public int hash(Vector vector){
 		int hash[] = new int[randomPartition.getDimensions()];
 		for(int d=0; d<randomPartition.getDimensions(); d++) {
-			hash[d] =  (int) (vector.get(d)-randomPartition.get(d) / Double.valueOf(w));
+			hash[d] =  (int) ((vector.get(d)-randomPartition.get(d)) / Double.valueOf(w));
 		}
 		return Arrays.hashCode(hash);
 	}

--- a/src/be/tarsos/lsh/families/CityBlockHash.java
+++ b/src/be/tarsos/lsh/families/CityBlockHash.java
@@ -41,7 +41,7 @@ public class CityBlockHash implements HashFunction {
 		for(int d=0; d<dimensions; d++) {
 			//mean 0
 			//standard deviation 1.0
-			double val = rand.nextInt(w);
+			double val = rand.nextDouble()*w;
 			randomPartition.set(d, val);
 		}
 	}

--- a/src/be/tarsos/lsh/families/CityBlockHashFamily.java
+++ b/src/be/tarsos/lsh/families/CityBlockHashFamily.java
@@ -42,8 +42,9 @@ public class CityBlockHashFamily implements HashFamily {
 	}
 
 	@Override
-	public Integer combine(int[] hashes) {
-		return Arrays.hashCode(hashes);
+	public String combine(int[] hashes) {
+		//return Arrays.hashCode(hashes);
+		return Arrays.toString(hashes);
 	}
 
 	@Override

--- a/src/be/tarsos/lsh/families/CosineHashFamily.java
+++ b/src/be/tarsos/lsh/families/CosineHashFamily.java
@@ -20,6 +20,7 @@
 
 package be.tarsos.lsh.families;
 
+import java.util.Arrays;
 
 public class CosineHashFamily implements HashFamily {
 	
@@ -39,18 +40,19 @@ public class CosineHashFamily implements HashFamily {
 	}
 
 	@Override
-	public Integer combine(int[] hashes) {
+	public String combine(int[] hashes) {
 		//Treat the hashes as a series of bits.
 		//They are either zero or one, the index 
 		//represents the value.
-		int result = 0;
+		//int result = 0;
 		//factor holds the power of two.
-		int factor = 1;
-		for(int i = 0 ; i < hashes.length ; i++){
-			result += hashes[i] == 0 ? 0 : factor;
-			factor *= 2;
-		}
-		return result;
+		//int factor = 1;
+		//for(int i = 0 ; i < hashes.length ; i++){
+			//result += hashes[i] == 0 ? 0 : factor;
+			//factor *= 2;
+		//}
+		//return result;
+		return Arrays.toString(hashes);
 	}
 
 	@Override

--- a/src/be/tarsos/lsh/families/EuclidianHashFamily.java
+++ b/src/be/tarsos/lsh/families/EuclidianHashFamily.java
@@ -41,8 +41,9 @@ public class EuclidianHashFamily implements HashFamily {
 	}
 	
 	@Override
-	public Integer combine(int[] hashes){
-		return Arrays.hashCode(hashes);
+	public String combine(int[] hashes){
+		//return Arrays.hashCode(hashes);
+		return Arrays.toString(hashes);
 	}
 
 	@Override

--- a/src/be/tarsos/lsh/families/HashFamily.java
+++ b/src/be/tarsos/lsh/families/HashFamily.java
@@ -49,7 +49,7 @@ public interface HashFamily extends Serializable {
 	 *         unique hash values result in a unique, deterministic combined
 	 *         hash value.
 	 */
-	Integer combine(int[] hashes);
+	String combine(int[] hashes);
 	
 	/**
 	 * Create a new distance measure.


### PR DESCRIPTION
For l1 distance LSH, the intention is to create "bins" of size `w` for each dimension.
The hash for that dimension is the bin number it is present in.
The complete hash is the aggregated hashes of all dimensions.
If two points are nearby, there is a high chance they will be in the same bin.
Source: <https://people.csail.mit.edu/indyk/p117-andoni.pdf> page 4

The original code calculates the hash for dimension `d` as follows:

    hash[d] =  (int) (vector.get(d)-randomPartition.get(d) / Double.valueOf(w));

However the above code is incorrect due to a missing bracket:

    hash[d] =  (int) Math.floor((vector.get(d)-randomPartition.get(d)) / Double.valueOf(w));

The modified code correctly partitions the points into bins, while the original code effectively makes all bins of size 1, putting each point in a seperate bin (unless they are *extremely* close together).

Another problem is caused by how Java rounds doubles to int: it simply strips off the fractional part, so the rounding is done towards 0. However for proper operation of the hash, numbers in (-1,0) should round to -1 and numbers in [0,1) should round to 0. Therefore Math.floor must be explicitly used instead of simply rounding down.

Yet another problem is that partitions should be chosen from reals, not ints. I fixed that too.

Finally, the entire signature should be used for mapping, instead of `Arrays.hashCode()`. So I converted the array of signatures to a string and used that.