### PR TITLE
Fixed benchmark neighbors mixup

### DIFF
--- a/src/be/tarsos/lsh/CommandLineInterface.java
+++ b/src/be/tarsos/lsh/CommandLineInterface.java
@@ -85,7 +85,7 @@ public class CommandLineInterface {
 				radius = 10;
 			}
 			dataset = TestUtils.generate(dimensions, 100,512);
-			TestUtils.addNeighbours(dataset, numberOfNeighbours, radius);
+			TestUtils.addNeighbours(dataset, 4, radius);
 		}
 		if(datasetFile !=null){
 			dataset = LSH.readDataset(datasetFile,Integer.MAX_VALUE);
@@ -154,7 +154,7 @@ public class CommandLineInterface {
 			for(int i = 0; i < numberOfHashes.length ; i++){
 				for(int j = 0 ; j < numberOfHashTables.length ; j++){	
 					lsh.buildIndex( numberOfHashes[i], numberOfHashTables[j]);
-					lsh.benchmark(numberOfNeighbours,family.createDistanceMeasure());	
+					lsh.benchmark(4,family.createDistanceMeasure());	
 				}
 			}
 		}


### PR DESCRIPTION
The benchmark prints at the start:

    Four close neighbours have been added to 100 vectors (100+4x100=500)

However

* Currently, the actual number of neighbors added is determined by `numberOfNeighbours`
* Currently, the benchmark searches for `numberOfNeighbours` neighbors

While `numberOfNeighbours` is 4 by default, the user can change it. So either we can change the displayed text at the start to correctly reflect the actual number of neighbors added, or we can fix the number of neighbors for the benchmark to 4. I've gone with the latter, but the former would be a valid fix too.